### PR TITLE
Gfortran issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+_build/*
+GIPL/cmake-build-debug/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ os:
   - linux
 
 env:
+  matrix:
+    - TRAVIS_PYTHON_VERSION="2.7"
+    - TRAVIS_PYTHON_VERSION="3.*"
+
   global:
     - CONDA_PREFIX=$HOME/conda
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
-    - TRAVIS_PYTHON_VERSION="3.*"
 
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: generic
 
 os:
   - osx
+  - linux
 
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,15 +26,16 @@ before_install:
   - source activate root
 
 install:
-  - cd $TRAVIS_BUILD_DIR
-  - mkdir install_test
   - mkdir _build && cd _build
-  - cmake .. -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_test
+  - cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX
+  - make
   - make install
 
 before_script:
-  - source ../scripts/update_rpaths.sh
+  - |
+    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
+      source ../bin/update_rpaths.sh
+    fi
 
 script: 
-  - cd $TRAVIS_BUILD_DIR/install_test/bin
-  - ./run_bmigipl_model test.cfg
+  - ctest --output-on-failure

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,8 @@ before_install:
   - hash -r
   - conda config --set always_yes yes --set changeps1 no
   - conda install python=$TRAVIS_PYTHON_VERSION
-  - |
-    if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      conda install gcc libgfortran cmake
-    else
-      conda install gfortran_linux-64 cmake
-      export FC=$CONDA_PREFIX/bin/x86_64-conda_cos6-linux-gnu-gfortran
-    fi
+  - conda install gfortran_$TRAVIS_OS_NAME-64 cmake
+  - source activate root
 
 install:
   - cd $TRAVIS_BUILD_DIR

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,14 @@
 language: generic
+
 os:
   - osx
+
 env:
   global:
     - CONDA_PREFIX=$HOME/conda
     - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
     - TRAVIS_PYTHON_VERSION="3.*"
-sudo: false
+
 before_install:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
@@ -29,14 +31,15 @@ before_install:
     fi
 
 install:
-- cd $TRAVIS_BUILD_DIR
-- mkdir install_test
-- mkdir _build && cd _build
-- cmake .. -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_test
-- make install
+  - cd $TRAVIS_BUILD_DIR
+  - mkdir install_test
+  - mkdir _build && cd _build
+  - cmake .. -DCMAKE_INSTALL_PREFIX=$TRAVIS_BUILD_DIR/install_test
+  - make install
+
 before_script:
-- source ../scripts/update_rpaths.sh
+  - source ../scripts/update_rpaths.sh
 
 script: 
-- cd $TRAVIS_BUILD_DIR/install_test/bin
-- ./run_bmigipl_model test.cfg
+  - cd $TRAVIS_BUILD_DIR/install_test/bin
+  - ./run_bmigipl_model test.cfg

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ os:
 env:
   global:
     - CONDA_PREFIX=$HOME/conda
-    - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda2-latest"
-    - TRAVIS_PYTHON_VERSION="2.7"
+    - MINICONDA_URL_BASE="https://repo.continuum.io/miniconda/Miniconda3-latest"
+    - TRAVIS_PYTHON_VERSION="3.*"
 sudo: false
 before_install:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,7 @@ install:
 before_script:
   - |
     if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      source ../bin/update_rpaths.sh
+      source ../scripts/update_rpaths.sh
     fi
 
 script: 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 # set fortran compiler
-#set(CMAKE_Fortran_COMPILER gfortran-mp-9) 
+set(CMAKE_Fortran_COMPILER gfortran-mp-9) 
 #set(CMAKE_Fortran_FLAGS --std=legacy)
 
 project(bmigipl Fortran)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 set(CMAKE_MACOSX_RPATH 1)
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 
-add_subdirectory(gipl)
-add_subdirectory(gipl/tests)
-add_subdirectory(gipl/examples)
+add_subdirectory(GIPL)
+add_subdirectory(GIPL/tests)
+add_subdirectory(GIPL/examples)
 
 include(CTest)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
 
 # set fortran compiler
-set(CMAKE_Fortran_COMPILER gfortran-mp-9) 
+# set(CMAKE_Fortran_COMPILER gfortran-mp-9) 
 #set(CMAKE_Fortran_FLAGS --std=legacy)
 
 project(bmigipl Fortran)

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -645,14 +645,19 @@ contains
             bmi_status = BMI_SUCCESS
         case("model_soil_layer__count")
             var_size = 1
+            bmi_status = BMI_SUCCESS
         case("soil__temperature")
-            var_size = (self%model%n_z)
+            var_size = self%model%n_z
+            bmi_status = BMI_SUCCESS
         case("soil_water__volume_fraction")
-            var_size = (self%model%n_lay)
+            var_size = self%model%n_lay
+            bmi_status = BMI_SUCCESS
         case("soil_unfrozen_water__a")
-            var_size = (self%model%n_lay)
+            var_size = self%model%n_lay
+            bmi_status = BMI_SUCCESS
         case("soil_unfrozen_water__b")
-            var_size = (self%model%n_lay)
+            var_size = self%model%n_lay
+            bmi_status = BMI_SUCCESS
         case default
             var_size = -1
             bmi_status = BMI_FAILURE
@@ -670,7 +675,7 @@ contains
         s1 = self%get_var_grid(var_name, grid_id)
         s2 = self%get_grid_size(grid_id, grid_size)
         s3 = self%get_var_itemsize(var_name, item_size)
-
+        
         if ((s1 == BMI_SUCCESS).and.(s2 == BMI_SUCCESS).and.(s3 == BMI_SUCCESS)) then
             var_nbytes = item_size * grid_size
             bmi_status = BMI_SUCCESS

--- a/GIPL/examples/CMakeLists.txt
+++ b/GIPL/examples/CMakeLists.txt
@@ -19,44 +19,44 @@ make_example(vargrid_ex)
 
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.cfg
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples)
   
 file(
   COPY ${data_dir}/in/bound.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
   
 file(
   COPY ${data_dir}/in/geo.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
   
 file(
   COPY ${data_dir}/in/grid.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
   
 file(
   COPY ${data_dir}/in/initial.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
 
 file(
   COPY ${data_dir}/in/rsnow.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
 
 file(
   COPY ${data_dir}/in/snow.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
   
 file(
   COPY ${data_dir}/in/sites.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
   
 file(
   COPY ${data_dir}/in/vegetation.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/in/)
   
 file(
   COPY ${data_dir}/output/result.txt.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples/output/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples/output/)
   
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test2.cfg
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/examples)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/examples)

--- a/GIPL/examples/change_air_temperature_ex.f90
+++ b/GIPL/examples/change_air_temperature_ex.f90
@@ -2,10 +2,11 @@
 program change_air_temperature_ex
 
   use bmigiplf
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   use testing_helpers, only: print_array
   implicit none
 
-  character (len=*), parameter :: config_file = "test.cfg"
+  character (len=BMI_MAX_VAR_NAME), parameter :: config_file = "test.cfg"
   character (len=*), parameter :: &
        dname = "land_surface_air__temperature"
   character (len=*), parameter :: &

--- a/GIPL/examples/get_value_ex.f90
+++ b/GIPL/examples/get_value_ex.f90
@@ -9,13 +9,14 @@ program get_value_ex
   type (bmi_gipl) :: m
   integer :: s, i, j, grid_id
   character (len=BMI_MAX_VAR_NAME), pointer :: names(:)
+  character (len=BMI_MAX_VAR_NAME), parameter :: config_file = "test.cfg"
   integer :: grid_size, dims(2), locations(3)
   real, allocatable :: z(:), y(:)
   real, pointer :: x(:)
   double precision :: time
 
   write (*,"(a)",advance="no") "Initializing..."
-  s = m%initialize("test.cfg")
+  s = m%initialize(config_file)
   write (*,*) "Done."
 
   s = m%get_output_var_names(names)

--- a/GIPL/examples/irf_ex.f90
+++ b/GIPL/examples/irf_ex.f90
@@ -1,7 +1,7 @@
 ! Test the lifecycle and time BMI methods.
 program irf_test
 
-  use bmif_1_2, only: BMI_MAX_UNITS_NAME
+  use bmif_1_2, only: BMI_MAX_UNITS_NAME, BMI_MAX_VAR_NAME
   use bmigiplf
   implicit none
 
@@ -9,9 +9,9 @@ program irf_test
   integer :: s, i
   double precision :: time, time0, time1
   character (len=BMI_MAX_UNITS_NAME) :: time_units
-
+  character (len=BMI_MAX_VAR_NAME), parameter :: config_file = "test.cfg"
   write (*,"(a)",advance="no") "Initializing..."
-  s = m%initialize("test.cfg")
+  s = m%initialize(config_file)
   write (*,*) "Done."
 
   s = m%get_start_time(time0)

--- a/GIPL/examples/set_value_ex.f90
+++ b/GIPL/examples/set_value_ex.f90
@@ -9,13 +9,14 @@ program set_value_ex
   type (bmi_gipl) :: m
   integer :: s, i, j, grid_id
   character (len=BMI_MAX_VAR_NAME), pointer :: names(:)
+  character (len=BMI_MAX_VAR_NAME), parameter :: config_file = "test.cfg"
   integer :: grid_size, dims(2), locations(3)
   real :: values(3)
   real, allocatable :: z(:), y(:)
   character(len=30) :: rowfmt
 
   write (*,"(a)",advance="no") "Initializing..."
-  s = m%initialize("test.cfg")
+  s = m%initialize(config_file)
   write (*,*) "Done."
 
   s = m%get_input_var_names(names)

--- a/GIPL/examples/vargrid_ex.f90
+++ b/GIPL/examples/vargrid_ex.f90
@@ -39,8 +39,8 @@ program vargrid_test
   write (*,"(a, 3(1x, i3))") "Grid shape:", iarray
   s = m%get_grid_size(grid_id, asize)
   write (*,"(a, i8)") "Grid size:", asize
-  s = m%get_grid_spacing(grid_id, darray2)
-  write (*,"(a, 1x, 5(f8.4))") "Grid spacing:", darray2(1:5)
+  ! s = m%get_grid_spacing(grid_id, darray2)
+  ! write (*,"(a, 1x, 5(f8.4))") "Grid spacing:", darray2(1:5)
   
   s = m%get_var_itemsize(names(1), asize)
   write (*,"(a, i8, 1x, a)") "Item size:", asize, "bytes"

--- a/GIPL/examples/vargrid_ex.f90
+++ b/GIPL/examples/vargrid_ex.f90
@@ -10,12 +10,14 @@ program vargrid_test
   character (len=BMI_MAX_VAR_NAME), pointer :: names(:)
   integer :: grid_id
   character (len=BMI_MAX_VAR_NAME) :: astring
+  character (len=BMI_MAX_VAR_NAME), parameter :: config_file = "test.cfg"
   integer :: asize
-  double precision, dimension(2) :: darray
-  integer, dimension(2) :: iarray
+  double precision, dimension(3) :: darray
+  integer, dimension(3) :: iarray
+  double precision, dimension(176) :: darray2
 
   write (*,"(a)",advance="no") "Initializing..."
-  s = m%initialize("test.cfg")
+  s = m%initialize(config_file)
   write (*,*) "Done."
 
   s = m%get_output_var_names(names)
@@ -30,16 +32,16 @@ program vargrid_test
   s = m%get_grid_type(grid_id, astring)
   write (*,"(a, 1x, a)") "Grid type:", trim(astring)
   s = m%get_grid_origin(grid_id, darray)
-  write (*,"(a, 1x, 2(f8.2))") "Grid origin:", darray
+  write (*,"(a, 1x, 3(f8.2))") "Grid origin:", darray
   s = m%get_grid_rank(grid_id, asize)
   write (*,"(a, i3)") "Grid rank:", asize
   s = m%get_grid_shape(grid_id, iarray)
-  write (*,"(a, 2(1x, i3))") "Grid shape:", iarray
+  write (*,"(a, 3(1x, i3))") "Grid shape:", iarray
   s = m%get_grid_size(grid_id, asize)
   write (*,"(a, i8)") "Grid size:", asize
-  s = m%get_grid_spacing(grid_id, darray)
-  write (*,"(a, 1x, 2(f8.2))") "Grid spacing:", darray
-
+  s = m%get_grid_spacing(grid_id, darray2)
+  write (*,"(a, 1x, 5(f8.4))") "Grid spacing:", darray2(1:5)
+  
   s = m%get_var_itemsize(names(1), asize)
   write (*,"(a, i8, 1x, a)") "Item size:", asize, "bytes"
   s = m%get_var_nbytes(names(1), asize)

--- a/GIPL/gipl.f90
+++ b/GIPL/gipl.f90
@@ -870,7 +870,7 @@ contains
                 model%zdepth = zdepth
                 model%zdepth_id = zdepth_id
 
-                model%dz = dz
+                model%dz = dz * zdepth(n_grd)
                 model%temp = temp
                 model%lay_id = lay_id
                 model%temp_frz = temp_frz

--- a/GIPL/tests/CMakeLists.txt
+++ b/GIPL/tests/CMakeLists.txt
@@ -33,40 +33,40 @@ make_test(test_get_grid_rank)
 
 file(
   COPY ${CMAKE_CURRENT_SOURCE_DIR}/test.cfg
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests)
   
 file(
   COPY ${data_dir}/in/bound.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
   
 file(
   COPY ${data_dir}/in/geo.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
   
 file(
   COPY ${data_dir}/in/grid.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
   
 file(
   COPY ${data_dir}/in/initial.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
 
 file(
   COPY ${data_dir}/in/rsnow.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
 
 file(
   COPY ${data_dir}/in/snow.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
   
 file(
   COPY ${data_dir}/in/sites.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
   
 file(
   COPY ${data_dir}/in/vegetation.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/in/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/in/)
   
 file(
   COPY ${data_dir}/output/result.txt.txt
-  DESTINATION ${CMAKE_BINARY_DIR}/gipl/tests/output/)
+  DESTINATION ${CMAKE_BINARY_DIR}/GIPL/tests/output/)

--- a/GIPL/tests/fixtures.f90
+++ b/GIPL/tests/fixtures.f90
@@ -1,8 +1,9 @@
 module fixtures
-
+  
+  use bmif_1_2, only: BMI_MAX_VAR_NAME
   implicit none
-
-  character (len=*), parameter :: config_file = "test.cfg"
+  
+  character (len=BMI_MAX_VAR_NAME), parameter :: config_file = "test.cfg"
 
   integer :: status
 

--- a/GIPL/tests/test_get_value.f90
+++ b/GIPL/tests/test_get_value.f90
@@ -2,11 +2,10 @@ program test_get_value
 
   use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmigiplf
-  use fixtures, only: status, print_array
+  use fixtures, only: status, print_array, config_file
 
   implicit none
 
-  character (len=256), parameter :: config_file = "test.cfg"
   type (bmi_gipl) :: m
   integer :: retcode
 

--- a/GIPL/tests/test_get_value.f90
+++ b/GIPL/tests/test_get_value.f90
@@ -6,7 +6,7 @@ program test_get_value
 
   implicit none
 
-  character (len=*), parameter :: config_file = "test.cfg"
+  character (len=256), parameter :: config_file = "test.cfg"
   type (bmi_gipl) :: m
   integer :: retcode
 
@@ -40,7 +40,7 @@ contains
     status = m%get_value(var_name, tval)
     status = m%finalize()
     
-    print *, tval(1), abs(tval(1) - expected)
+    print *, abs(tval(1) - expected)
 
     ! Visual inspection.
     write(*,*) "Test 1"

--- a/GIPL/tests/test_initialize.f90
+++ b/GIPL/tests/test_initialize.f90
@@ -2,17 +2,15 @@ program test_initialize
 
   use bmif_1_2, only: BMI_FAILURE
   use bmigiplf
-  use fixtures, only: status
+  use fixtures, only: status, config_file
 
   implicit none
-
-  character (len=256), parameter :: config_file1 = "test.cfg"
 
   type (bmi_gipl) :: m
   integer :: status1, status2, s
   real*8 :: end_time
 
-  status1 = m%initialize(config_file1)
+  status1 = m%initialize(config_file)
   status = m%finalize()
     
   if (status1 .ne. 0) then

--- a/GIPL/tests/test_initialize.f90
+++ b/GIPL/tests/test_initialize.f90
@@ -6,7 +6,7 @@ program test_initialize
 
   implicit none
 
-  character (len=*), parameter :: config_file1 = "test.cfg"
+  character (len=256), parameter :: config_file1 = "test.cfg"
 
   type (bmi_gipl) :: m
   integer :: status1, status2, s

--- a/GIPL/tests/test_set_value.f90
+++ b/GIPL/tests/test_set_value.f90
@@ -2,11 +2,11 @@ program test_set_value
 
   use bmif_1_2, only: BMI_SUCCESS, BMI_FAILURE
   use bmigiplf
-  use fixtures, only: status, print_array
+  use fixtures, only: status, print_array, config_file
 
   implicit none
 
-  character (len=*), parameter :: config_file = "test.cfg"
+  !character (len=256), parameter :: config_file = "test.cfg"
   type (bmi_gipl) :: m
   integer :: retcode
 

--- a/scripts/update_rpaths.sh
+++ b/scripts/update_rpaths.sh
@@ -16,8 +16,13 @@ fi
 
 echo $CONDA_PREFIX
 
-examples="info_ex"
-
+examples="info_ex \
+    irf_ex \
+    get_value_ex \
+    set_value_ex \
+    conflicting_instances_ex \
+    change_air_temperature_ex \
+    vargrid_ex"
 for exe in $examples; do
     run_install_name_tool $exe examples
 done


### PR DESCRIPTION
@mdpiper, I think I found and fixed the fault occurring in gfortran but disappearing in Intel Fortran compiler.

It seems like the length of the character variables. I defined the length of the configuration file name to 256. If we defined a file name with LEN=*, it will be an error in gfortran compile. Intel Fortran compiler may be tolerant. I tried to find any compiler flag in gfortran while didn't find yet. Right now, the solution is to change all character variable length to a specific length. I used "BMI_MAX_VAR_NAME" for them now. All the tests passed. Please check them again. If there are still any errors or questions, please let me know.

Hoping we can make this component available soon in PyMT.

Please also consider moving the line "set(CMAKE_Fortran_COMPILER gfortran-mp-9)" in the "CMakeLists.txt". It is used to specify the compiler on my computer. 