### PR TITLE
Update BMI for one-dimensional grids

### DIFF
--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -636,28 +636,28 @@ contains
 
         select case(var_name)
         case("land_surface_air__temperature")
-            var_size = 1  ! 'sizeof' in gcc & ifort
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case("snowpack__depth")
-            var_size = 1        ! 'sizeof' in gcc & ifort
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case("snow__thermal_conductivity")
-            var_size = 1        ! 'sizeof' in gcc & ifort
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case("model_soil_layer__count")
-            var_size = 1
+            var_size = 2
             bmi_status = BMI_SUCCESS
         case("soil__temperature")
-            var_size = self%model%n_z
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case("soil_water__volume_fraction")
-            var_size = self%model%n_lay
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case("soil_unfrozen_water__a")
-            var_size = self%model%n_lay
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case("soil_unfrozen_water__b")
-            var_size = self%model%n_lay
+            var_size = 4
             bmi_status = BMI_SUCCESS
         case default
             var_size = -1

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -319,7 +319,7 @@ contains
             grid_type = "scalar"
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_type = "three_dims"
+            grid_type = "rectilinear"
             bmi_status = BMI_SUCCESS
         case default
             grid_type = "-"

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -319,7 +319,7 @@ contains
             grid_type = "scalar"
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_type = "rectilinear"
+            grid_type = "vector"
             bmi_status = BMI_SUCCESS
         case default
             grid_type = "-"
@@ -342,7 +342,7 @@ contains
             grid_rank = 0
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_rank = 3
+            grid_rank = 1
             bmi_status = BMI_SUCCESS
         case default
             grid_rank = -1
@@ -365,7 +365,7 @@ contains
             grid_shape = [1]
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_shape = [self%model%n_y, self%model%n_x, self%model%n_z]
+            grid_shape = [self%model%n_z]
             bmi_status = BMI_SUCCESS
         case default
             grid_shape = [-1]
@@ -388,7 +388,7 @@ contains
             grid_size = 1
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_size = self%model%n_y * self%model%n_x * self%model%n_z
+            grid_size =  self%model%n_z
             bmi_status = BMI_SUCCESS
         case default
             grid_size = -1
@@ -434,7 +434,7 @@ contains
             grid_origin = [0.d0]
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_origin = [0.d0, 0.d0, 0.d0]
+            grid_origin = [0.d0]
             bmi_status = BMI_SUCCESS
         case default
             grid_origin = [-1.d0]
@@ -527,7 +527,7 @@ contains
             grid_conn = [0]
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_conn = [0, 0, 0]
+            grid_conn = [0]
             bmi_status = BMI_SUCCESS
         case default
             grid_conn = [-1]
@@ -551,7 +551,7 @@ contains
             grid_offset = [0]
             bmi_status = BMI_SUCCESS
         case(2)
-            grid_offset = [0, 0, 0]
+            grid_offset = [0]
             bmi_status = BMI_SUCCESS
         case default
             grid_offset = [-1]

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -315,7 +315,7 @@ contains
 
         select case(grid_id)
         case(0)
-            grid_type = "rectilinear"
+            grid_type = "points"
             bmi_status = BMI_SUCCESS
         case(1)
             grid_type = "scalar"

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -293,8 +293,10 @@ contains
             bmi_status = BMI_SUCCESS
         case('soil_unfrozen_water__a')
             grid_id = 2
+            bmi_status = BMI_SUCCESS
         case('soil_unfrozen_water__b')
             grid_id = 2
+            bmi_status = BMI_SUCCESS
         case('soil__temperature')
             grid_id = 2
             bmi_status = BMI_SUCCESS

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -343,6 +343,7 @@ contains
             bmi_status = BMI_SUCCESS
         case(2)
             grid_rank = 3
+            bmi_status = BMI_SUCCESS
         case default
             grid_rank = -1
             bmi_status = BMI_FAILURE

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -895,6 +895,9 @@ contains
         case('soil_unfrozen_water__b')
             print*, "please use [set_value_at_indices]"
             bmi_status = BMI_FAILURE
+        case("soil__temperature")
+            self%model%temp = reshape(src, [self%model%n_site, self%model%n_z])
+            bmi_status = BMI_SUCCESS
         case default
             bmi_status = BMI_FAILURE
         end select

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -405,14 +405,14 @@ contains
 
         select case(grid_id)
         case(0)
-            grid_spacing = [self%model%dy, self%model%dx]
-            bmi_status = BMI_SUCCESS
+            grid_spacing = [-1.d0]
+            bmi_status = BMI_FAILURE
         case(1)
-            grid_spacing = [self%model%dx]
-            bmi_status = BMI_SUCCESS
+            grid_spacing = [-1.d0]
+            bmi_status = BMI_FAILURE
         case(2)
-            grid_spacing = [self%model%dy, self%model%dx, self%model%dz]
-            bmi_status = BMI_SUCCESS
+            grid_spacing = [-1.d0]
+            bmi_status = BMI_FAILURE
         case default
             grid_spacing = [-1.d0]
             bmi_status = BMI_FAILURE

--- a/GIPL/bmigiplf.f90
+++ b/GIPL/bmigiplf.f90
@@ -779,7 +779,10 @@ contains
         type (c_ptr) :: src
         integer :: n_elements
 
-        return
+        select case(var_name)
+        case default
+            bmi_status = BMI_FAILURE
+        end select
     end function gipl_get_ptr_float
 
     ! Get a reference to an double-valued variable, flattened.

--- a/GIPL/tests/test_get_grid_type.f90
+++ b/GIPL/tests/test_get_grid_type.f90
@@ -8,7 +8,7 @@ program test_get_grid_type
 
   integer, parameter :: grid_id = 0
   character (len=*), parameter :: &
-       expected_type = "rectilinear"
+       expected_type = "points"
 
   type (bmi_gipl) :: m
   character (len=BMI_MAX_TYPE_NAME) :: grid_type


### PR DESCRIPTION
This PR represents a group of minor updates to the GIPL BMI to allow it run in pymt. Furthermore, after discussion with @wk1984 and @mcflugen, the BMI now interacts with GIPL as a 1D model, even though GIPL has the capability to represent independent, horizontally distributed points. This capability will instead be represented in pymt by creating multiple instances of the 1D GIPL component. 