### PR TITLE
Update CMake build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,6 @@ set(bmigipl_lib bmigiplf)
 set(data_dir ${CMAKE_SOURCE_DIR}/data)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)
 
-set(CMAKE_MACOSX_RPATH 1)
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
-
 add_subdirectory(GIPL)
 add_subdirectory(GIPL/tests)
 add_subdirectory(GIPL/examples)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8)
+cmake_minimum_required(VERSION 3.12)
 
 # set fortran compiler
 # set(CMAKE_Fortran_COMPILER gfortran-mp-9) 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@
 > `mkdir _build && cd _build`  
 > `cmake .. -DCMAKE_INSTALL_PREFIX=[install_path]`  
 > `make install`  
-> `source ../scripts/update_rpaths.sh`  
 > `ctest`
 > 
 


### PR DESCRIPTION
This is a small PR to update the minimum CMake version and remove an obsolete fix for rpaths on macOS.