### PR TITLE
Add Windows to CI testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,6 +90,6 @@ jobs:
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: |
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.dll.a
-          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmigiplf.dll
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.dll.a ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmigiplf.dll ) ){ exit 1 }
           ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,3 +53,42 @@ jobs:
         run: |
           test -h $CONDA_PREFIX/lib/libbmigiplf${{ env.SHLIB_EXT }}
           ctest
+
+  build-on-windows:
+
+    if:
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
+      github.repository
+
+    runs-on: windows-latest
+
+    env:
+      LIBRARY_PREFIX: $env:CONDA_PREFIX\Library
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: mamba-org/setup-micromamba@v2
+        with:
+          micromamba-version: latest
+          environment-name: testing
+          create-args: >-
+            cmake
+            cxx-compiler
+          init-shell: >-
+            powershell
+
+      - name: Make cmake build directory
+        run: cmake -E make_directory build
+
+      - name: Configure, build, and install
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake --build . --target install --config Release
+
+      - name: Test
+        working-directory: ${{ github.workspace }}/build
+        run: |
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.a ) ){ exit 1 }
+          ctest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,5 +90,6 @@ jobs:
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: |
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.dll.a
+          Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmigiplf.dll
           ctest
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.a ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,5 +90,5 @@ jobs:
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.a ) ){ exit 1 }
           ctest
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.a ) ){ exit 1 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,6 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(bmigipl
-  VERSION 1.3.dev0
-  LANGUAGES Fortran
-)
+project(bmigipl Fortran)
 
 include(GNUInstallDirs)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,8 @@
 cmake_minimum_required(VERSION 3.12)
 
-# set fortran compiler
-# set(CMAKE_Fortran_COMPILER gfortran-mp-9) 
-#set(CMAKE_Fortran_FLAGS --std=legacy)
-
 project(bmigipl Fortran)
+
+include(GNUInstallDirs)
 
 set(bmi_version 1.0)
 set(bmigipl_lib bmigiplf)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.12)
 
-project(bmigipl Fortran)
+project(bmigipl
+  VERSION 1.3.dev0
+  LANGUAGES Fortran
+)
 
 include(GNUInstallDirs)
 

--- a/GIPL/CMakeLists.txt
+++ b/GIPL/CMakeLists.txt
@@ -11,18 +11,21 @@ add_executable(run_bmi${pkg_name} bmi_main.f90)
 target_link_libraries(run_bmi${pkg_name} ${bmigipl_lib})
 
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_${pkg_name}
-  DESTINATION bin
-  COMPONENT ${pkg_name})
+  TARGETS run_${pkg_name}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 install(
-  PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/run_bmi${pkg_name}
-  DESTINATION bin
-  COMPONENT ${pkg_name})
+  TARGETS run_bmi${pkg_name}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 install(
   TARGETS ${bmigipl_lib}
-  DESTINATION lib
-  COMPONENT ${pkg_name})
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+)
 install(
   FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
         ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmigipl_lib}.mod
-  DESTINATION include)
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)


### PR DESCRIPTION
This PR adds Windows to the CI testing workflow. To make this easier, I reorganized the CMake build process around the `GNUInstallDirs` variables.