### PR TITLE
Expose model and BMI as libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ project(bmigipl Fortran)
 
 include(GNUInstallDirs)
 
+set(model_name gipl_model)
 set(bmi_major_version 1)
 set(bmi_minor_version 2)
 set(bmi_version ${bmi_major_version}.${bmi_minor_version})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,9 @@ project(bmigipl Fortran)
 
 include(GNUInstallDirs)
 
-set(bmi_version 1.0)
+set(bmi_major_version 1)
+set(bmi_minor_version 2)
+set(bmi_version ${bmi_major_version}.${bmi_minor_version})
 set(bmigipl_lib bmigiplf)
 set(data_dir ${CMAKE_SOURCE_DIR}/data)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)

--- a/GIPL/CMakeLists.txt
+++ b/GIPL/CMakeLists.txt
@@ -1,9 +1,7 @@
-set(pkg_name gipl_model)
-
 # GIPL model
-add_library(${pkg_name} SHARED gipl.f90)
-set_target_properties(${pkg_name} PROPERTIES
-  PUBLIC_HEADER ${CMAKE_Fortran_MODULE_DIRECTORY}/${pkg_name}.mod
+add_library(${model_name} SHARED gipl.f90)
+set_target_properties(${model_name} PROPERTIES
+  PUBLIC_HEADER ${CMAKE_Fortran_MODULE_DIRECTORY}/${model_name}.mod
 )
 
 # BMI specification
@@ -15,19 +13,19 @@ set_target_properties(bmif PROPERTIES
 
 # BMI for GIPL model
 add_library(${bmigipl_lib} SHARED bmigiplf.f90)
-target_link_libraries(${bmigipl_lib} ${pkg_name} bmif)
+target_link_libraries(${bmigipl_lib} ${model_name} bmif)
 set_target_properties(${bmigipl_lib} PROPERTIES
   PUBLIC_HEADER ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmigipl_lib}.mod
 )
 
 # Executable main programs
-add_executable(run_${pkg_name} main.f90)
-target_link_libraries(run_${pkg_name} ${pkg_name})
-add_executable(run_bmi${pkg_name} bmi_main.f90)
-target_link_libraries(run_bmi${pkg_name} ${bmigipl_lib})
+add_executable(run_${model_name} main.f90)
+target_link_libraries(run_${model_name} ${model_name})
+add_executable(run_bmi${model_name} bmi_main.f90)
+target_link_libraries(run_bmi${model_name} ${bmigipl_lib})
 
 install(
-  TARGETS ${pkg_name}
+  TARGETS ${model_name}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -48,10 +46,10 @@ install(
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 install(
-  TARGETS run_${pkg_name}
+  TARGETS run_${model_name}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(
-  TARGETS run_bmi${pkg_name}
+  TARGETS run_bmi${model_name}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )

--- a/GIPL/CMakeLists.txt
+++ b/GIPL/CMakeLists.txt
@@ -1,15 +1,52 @@
 set(pkg_name gipl_model)
-set(mod_name ${pkg_name})
-set(src_${pkg_name} gipl.f90 main.f90)
-set(src_bmi${pkg_name} gipl.f90 bmigiplf.f90 bmi.f90)
 
-add_library(${bmigipl_lib} SHARED ${src_bmi${pkg_name}})
+# GIPL model
+add_library(${pkg_name} SHARED gipl.f90)
+set_target_properties(${pkg_name} PROPERTIES
+  PUBLIC_HEADER ${CMAKE_Fortran_MODULE_DIRECTORY}/${pkg_name}.mod
+)
 
-add_executable(run_${pkg_name} ${src_${pkg_name}})
+# BMI specification
+add_library(bmif SHARED bmi.f90)
+set_target_properties(bmif PROPERTIES
+  VERSION ${bmi_version}
+  PUBLIC_HEADER ${CMAKE_Fortran_MODULE_DIRECTORY}/bmif_${bmi_major_version}_${bmi_minor_version}.mod
+)
 
+# BMI for GIPL model
+add_library(${bmigipl_lib} SHARED bmigiplf.f90)
+target_link_libraries(${bmigipl_lib} ${pkg_name} bmif)
+set_target_properties(${bmigipl_lib} PROPERTIES
+  PUBLIC_HEADER ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmigipl_lib}.mod
+)
+
+# Executable main programs
+add_executable(run_${pkg_name} main.f90)
+target_link_libraries(run_${pkg_name} ${pkg_name})
 add_executable(run_bmi${pkg_name} bmi_main.f90)
 target_link_libraries(run_bmi${pkg_name} ${bmigipl_lib})
 
+install(
+  TARGETS ${pkg_name}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  TARGETS bmif
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+install(
+  TARGETS ${bmigipl_lib}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 install(
   TARGETS run_${pkg_name}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
@@ -17,15 +54,4 @@ install(
 install(
   TARGETS run_bmi${pkg_name}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-install(
-  TARGETS ${bmigipl_lib}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
-)
-install(
-  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
-        ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmigipl_lib}.mod
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )


### PR DESCRIPTION
This PR changes the build to create shared libraries for the GIPL model and the BMI specification that's bundled with it.