### PR TITLE
Fix build and CI on Windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on: [push, pull_request]
 
 env:
   BMI_VERSION: 1_2
+  BUILD_DIR: _build
 
 jobs:
   build-on-unix:
@@ -38,15 +39,15 @@ jobs:
             fortran-compiler
 
       - name: Configure project
-        run: cmake -B _build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
+        run: cmake -B ${{ env.BUILD_DIR }} -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
 
       - name: Build and install
-        run: cmake --build _build --target install --config Release
+        run: cmake --build ${{ env.BUILD_DIR }} --target install --config Release
 
       - name: Test
         run: |
           test -h $CONDA_PREFIX/lib/libbmigiplf${{ env.SHLIB_EXT }}
-          ctest --test-dir _build
+          ctest --test-dir ${{ env.BUILD_DIR }}
 
   build-on-windows:
 
@@ -79,12 +80,12 @@ jobs:
 
       - name: Configure, build, and install project
         run: |
-          cmake -B _build -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
-          cmake --build _build --target install --config Release
+          cmake -B ${{ env.BUILD_DIR }} -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake --build ${{ env.BUILD_DIR }} --target install --config Release
 
       - name: Test
         run: |
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_bmigipl_model.exe ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmigiplf.lib ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmigiplf.mod ) ){ exit 1 }
-          ctest --test-dir _build
+          ctest --test-dir ${{ env.BUILD_DIR }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,12 +67,15 @@ jobs:
           environment-name: testing
           create-args: >-
             cmake
+            pkg-config
             cxx-compiler
+            fortran-compiler
           init-shell: >-
             powershell
 
-      - name: Make cmake build directory
-        run: cmake -E make_directory build
+      - name: Set the FC environment variable to the Fortran conda compiler
+        run: |
+          echo "FC=$CONDA_PREFIX/Library/bin/flang-new.exe" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf8 -Append
 
       - name: Configure, build, and install project
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -84,6 +84,7 @@ jobs:
 
       - name: Test
         run: |
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.dll.a ) ){ exit 1 }
-          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmigiplf.dll ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\run_bmigipl_model.exe ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\bmigiplf.lib ) ){ exit 1 }
+          if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\include\bmigiplf.mod ) ){ exit 1 }
           ctest --test-dir _build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Test
         run: |
           test -h $CONDA_PREFIX/lib/libbmigiplf${{ env.SHLIB_EXT }}
-          ctest
+          ctest --test-dir _build
 
   build-on-windows:
 
@@ -83,4 +83,4 @@ jobs:
         run: |
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.dll.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmigiplf.dll ) ){ exit 1 }
-          ctest
+          ctest --test-dir _build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,8 +9,7 @@ jobs:
   build-on-unix:
 
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: ${{ matrix.os }}
 
@@ -35,21 +34,16 @@ jobs:
           create-args: >-
             make
             cmake
+            pkg-config
             fortran-compiler
 
-      - name: Make build directory
-        run: cmake -E make_directory build
-
-      - name: Configure
-        working-directory: ${{ github.workspace }}/build
-        run: cmake .. -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
+      - name: Configure project
+        run: cmake -B _build -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=Release
 
       - name: Build and install
-        working-directory: ${{ github.workspace }}/build
-        run: cmake --build . --target install --config Release
+        run: cmake --build _build --target install --config Release
 
       - name: Test
-        working-directory: ${{ github.workspace }}/build
         run: |
           test -h $CONDA_PREFIX/lib/libbmigiplf${{ env.SHLIB_EXT }}
           ctest
@@ -57,8 +51,7 @@ jobs:
   build-on-windows:
 
     if:
-      github.event_name == 'push' || github.event.pull_request.head.repo.full_name !=
-      github.repository
+      github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
 
     runs-on: windows-latest
 
@@ -81,14 +74,12 @@ jobs:
       - name: Make cmake build directory
         run: cmake -E make_directory build
 
-      - name: Configure, build, and install
-        working-directory: ${{ github.workspace }}/build
+      - name: Configure, build, and install project
         run: |
-          cmake .. -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
-          cmake --build . --target install --config Release
+          cmake -B _build -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake --build _build --target install --config Release
 
       - name: Test
-        working-directory: ${{ github.workspace }}/build
         run: |
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\lib\libbmigiplf.dll.a ) ){ exit 1 }
           if ( -not ( Test-Path -Path ${{ env.LIBRARY_PREFIX }}\bin\libbmigiplf.dll ) ){ exit 1 }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,7 +79,7 @@ jobs:
 
       - name: Configure, build, and install project
         run: |
-          cmake -B _build -G "NMake Makefiles" -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
+          cmake -B _build -G Ninja -DCMAKE_INSTALL_PREFIX="${{ env.LIBRARY_PREFIX }}" -DCMAKE_BUILD_TYPE=Release
           cmake --build _build --target install --config Release
 
       - name: Test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,6 @@ project(bmigipl Fortran)
 
 include(GNUInstallDirs)
 
-set(bmi_version 1.0)
 set(bmigipl_lib bmigiplf)
 set(data_dir ${CMAKE_SOURCE_DIR}/data)
 set(CMAKE_Fortran_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/mod)

--- a/GIPL/CMakeLists.txt
+++ b/GIPL/CMakeLists.txt
@@ -1,7 +1,11 @@
 set(pkg_name gipl_model)
 
 add_library(gipl OBJECT gipl.f90)
-add_library(${bmigipl_lib} SHARED bmigiplf.f90 bmi.f90 $<TARGET_OBJECTS:gipl>)
+if(WIN32)
+  add_library(${bmigipl_lib} STATIC bmigiplf.f90 bmi.f90 $<TARGET_OBJECTS:gipl>)
+else()
+  add_library(${bmigipl_lib} SHARED bmigiplf.f90 bmi.f90 $<TARGET_OBJECTS:gipl>)
+endif()
 
 add_executable(run_${pkg_name} main.f90 $<TARGET_OBJECTS:gipl>)
 add_executable(run_bmi${pkg_name} bmi_main.f90)

--- a/GIPL/CMakeLists.txt
+++ b/GIPL/CMakeLists.txt
@@ -1,8 +1,9 @@
 set(pkg_name gipl_model)
 
-add_library(${bmigipl_lib} SHARED gipl.f90 bmigiplf.f90 bmi.f90)
+add_library(gipl OBJECT gipl.f90)
+add_library(${bmigipl_lib} SHARED bmigiplf.f90 bmi.f90 $<TARGET_OBJECTS:gipl>)
 
-add_executable(run_${pkg_name} gipl.f90 main.f90)
+add_executable(run_${pkg_name} main.f90 $<TARGET_OBJECTS:gipl>)
 add_executable(run_bmi${pkg_name} bmi_main.f90)
 target_link_libraries(run_bmi${pkg_name} ${bmigipl_lib})
 

--- a/GIPL/CMakeLists.txt
+++ b/GIPL/CMakeLists.txt
@@ -1,12 +1,8 @@
 set(pkg_name gipl_model)
-set(mod_name ${pkg_name})
-set(src_${pkg_name} gipl.f90 main.f90)
-set(src_bmi${pkg_name} gipl.f90 bmigiplf.f90 bmi.f90)
 
-add_library(${bmigipl_lib} SHARED ${src_bmi${pkg_name}})
+add_library(${bmigipl_lib} SHARED gipl.f90 bmigiplf.f90 bmi.f90)
 
-add_executable(run_${pkg_name} ${src_${pkg_name}})
-
+add_executable(run_${pkg_name} gipl.f90 main.f90)
 add_executable(run_bmi${pkg_name} bmi_main.f90)
 target_link_libraries(run_bmi${pkg_name} ${bmigipl_lib})
 
@@ -25,7 +21,7 @@ install(
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 install(
-  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${mod_name}.mod
+  FILES ${CMAKE_Fortran_MODULE_DIRECTORY}/${pkg_name}.mod
         ${CMAKE_Fortran_MODULE_DIRECTORY}/${bmigipl_lib}.mod
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )

--- a/GIPL/examples/CMakeLists.txt
+++ b/GIPL/examples/CMakeLists.txt
@@ -2,9 +2,11 @@ include(CTest)
 
 include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
+add_library(helpers OBJECT testing_helpers.f90)
+
 function(make_example example_name)
   add_test(NAME ${example_name} COMMAND ${example_name})
-  set(src_${example_name} ${example_name}.f90 testing_helpers.f90)
+  set(src_${example_name} ${example_name}.f90 $<TARGET_OBJECTS:helpers>)
   add_executable(${example_name} ${src_${example_name}})
   target_link_libraries(${example_name} ${bmi_lib} ${bmigipl_lib})
 endfunction(make_example)

--- a/GIPL/examples/CMakeLists.txt
+++ b/GIPL/examples/CMakeLists.txt
@@ -6,9 +6,8 @@ add_library(helpers OBJECT testing_helpers.f90)
 
 function(make_example example_name)
   add_test(NAME ${example_name} COMMAND ${example_name})
-  set(src_${example_name} ${example_name}.f90 $<TARGET_OBJECTS:helpers>)
-  add_executable(${example_name} ${src_${example_name}})
-  target_link_libraries(${example_name} ${bmi_lib} ${bmigipl_lib})
+  add_executable(${example_name} ${example_name}.f90 $<TARGET_OBJECTS:helpers>)
+  target_link_libraries(${example_name} ${bmigipl_lib})
 endfunction(make_example)
 
 make_example(info_ex)

--- a/GIPL/tests/CMakeLists.txt
+++ b/GIPL/tests/CMakeLists.txt
@@ -2,9 +2,11 @@ include(CTest)
 
 include_directories(${CMAKE_Fortran_MODULE_DIRECTORY})
 
+add_library(fixtures OBJECT fixtures.f90)
+
 function(make_test test_name)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set(src_${test_name} ${test_name}.f90 fixtures.f90)
+  set(src_${test_name} ${test_name}.f90 $<TARGET_OBJECTS:fixtures>)
   add_executable(${test_name} ${src_${test_name}})
   target_link_libraries(${test_name} ${bmi_lib} ${bmigipl_lib})
 endfunction(make_test)

--- a/GIPL/tests/CMakeLists.txt
+++ b/GIPL/tests/CMakeLists.txt
@@ -6,9 +6,8 @@ add_library(fixtures OBJECT fixtures.f90)
 
 function(make_test test_name)
   add_test(NAME ${test_name} COMMAND ${test_name})
-  set(src_${test_name} ${test_name}.f90 $<TARGET_OBJECTS:fixtures>)
-  add_executable(${test_name} ${src_${test_name}})
-  target_link_libraries(${test_name} ${bmi_lib} ${bmigipl_lib})
+  add_executable(${test_name} ${test_name}.f90 $<TARGET_OBJECTS:fixtures>)
+  target_link_libraries(${test_name} ${bmigipl_lib})
 endfunction(make_test)
 
 make_test(test_get_component_name)


### PR DESCRIPTION
This PR addresses two problems in the CI testing on Windows:

1. the NMake build backend is erroring;
1. the wrong Fortran compiler is being used.

I changed the build backend to Ninja (which is what Meson uses) and forced it to use the conda Fortran compiler. I had to update the CMake build configuration in the project in order to make this work, which allowed me to make other minor improvements.

One failure of this update is that I haven't figured out how to make a shared library on Windows with this configuration, so I fell back on making a static library.